### PR TITLE
Fix menu witdth on long selected text

### DIFF
--- a/index.js
+++ b/index.js
@@ -177,7 +177,11 @@ const start = () => {
     translateMenu.setAttribute('hidden', !selection)
     if (!selection) return
 
-    translateMenu.setAttribute('label', strParams(LABEL_TRANSLATE, selection))
+    var selectionLabel = selection;
+    if (selectionLabel.length > 15) {
+      selectionLabel = selectionLabel.substr(0, 15)+"…";
+    }
+    translateMenu.setAttribute('label', strParams(LABEL_TRANSLATE, selectionLabel))
     updateResult(null)
     updateLangMenuLabel()
   }


### PR DESCRIPTION
Add ellipsis in selected text to translate is too long.
The number of chars kept are the same than built-in search menu item.