### PR TITLE
Fix the tab opening next to the current tab

### DIFF
--- a/index.js
+++ b/index.js
@@ -223,7 +223,10 @@ const initMenu = (win, languages) => {
 
     // Open the translation page
     if (target === result) {
-      tabs.open(translateUrl(currentFrom(languages).code, currentTo(languages).code, selection))
+      const browser = getMostRecentBrowserWindow().gBrowser
+      const url = translateUrl(currentFrom(languages).code, currentTo(languages).code, selection)
+      const tab = browser.loadOneTab(url, {relatedToCurrent: true})
+      browser.selectedTab = tab;
       return
     }
 


### PR DESCRIPTION
To solve the issue #34 
Based on the idea of @def00111 (plus I add the selection of the opened tab)
Tested of Firefox 38