### PR TITLE
Add github issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,14 @@
+#### What steps will reproduce the problem?
+1. 
+2. 
+3. 
+
+#### What is the expected behavior? What do you see instead?
+
+
+#### Could you describe us your platform?
+* Firefox version: 
+* Operating system: 
+
+#### Anything else to add to help us?
+


### PR DESCRIPTION
Github has [just released ~~the so waited~~ new templates](https://github.com/blog/2111-issue-and-pull-request-templates).
Here is a template to report issue. It should help to understand and reproduce the issue.
If you would like to see it in action, [check one of my projects](https://github.com/PerfectSlayer/scrollupfolder/issues/new). So, what do you think about it ? @bpierre @mote0230 