### PR TITLE
Add copy to the clipboard

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,8 +24,7 @@ const LABEL_LOADING = _('fetch_translation')
 const LABEL_TRANSLATE = _('translate')
 const LABEL_TRANSLATE_PAGE = _('translate_page')
 const LABEL_CHANGE_LANGUAGES = _('change_languages')
-
-const LABEL_CLIPBOARD = 'Copy'
+const LABEL_CLIPBOARD = _('copy_to_clipboard')
 
 // Get the available languages
 const getLanguages = () => new Promise((resolve) => {

--- a/index.js
+++ b/index.js
@@ -188,14 +188,12 @@ const initMenu = (win, languages) => {
   )
   const translatePopup = elt('menupopup', null, null, translateMenu)
 
-  const result = elt('menu', null, null, translatePopup)
-  const resultPopup = elt('menupopup', null, null, result)
-  const clipboardItem = elt(
-    'menuitem', null,
-    { label: LABEL_CLIPBOARD },
-    resultPopup
-  )
+  const result = elt('menuitem', null, null, translatePopup)
   elt('menuseparator', null, null, translatePopup)
+  const clipboardItem = elt(
+    'menuitem', null, { label: LABEL_CLIPBOARD },
+    translatePopup
+  )
   const langMenu = elt('menu', null, null, translatePopup)
   const fromPopup = elt('menupopup', null, null, langMenu)
   const fromMenus = langFromMenus(languages, doc)

--- a/locale/en-US.properties
+++ b/locale/en-US.properties
@@ -4,5 +4,6 @@ translate= Translate “{0}”
 translate_page= Translate Page ({0} > {1})
 change_languages= Change Languages ({0} > {1})
 language_detected= \ - detected
+copy_to_clipboard= Copy Translation
 
 google_translate_error= Google Translate Service Error

--- a/locale/fi.properties
+++ b/locale/fi.properties
@@ -16,5 +16,6 @@ translate= Käännä “{0}”
 translate_page= Käännä sivu ({0} > {1})
 change_languages= Vaihda kieliä ({0} > {1})
 language_detected= \ - tunnistettu
+copy_to_clipboard= Kopioi käännös
 
 google_translate_error= Google Kääntäjän palveluvirhe

--- a/providers/google-translate.js
+++ b/providers/google-translate.js
@@ -3,6 +3,8 @@
 
 const request = require('sdk/request').Request
 
+const LABEL_TRANSLATE_ERROR = 'Google Translate Service Error'
+
 function translationResult(str, onError) {
   let newstr = '['
   let insideQuote = false
@@ -33,7 +35,7 @@ function translationResult(str, onError) {
     parseError = true
   }
 
-  const translation = parseError ? 'Google Translate Service Error' : (
+  const translation = parseError ? LABEL_TRANSLATE_ERROR : (
     result[0] && result[0].map(chunk => chunk[0]).join(' ')
   ) || null
 
@@ -169,3 +171,4 @@ function translate(from, to, text, cb) {
 exports.translate = translate
 exports.translateUrl = pageUrl
 exports.translatePageUrl = wholePageUrl
+exports.LABEL_TRANSLATE_ERROR = LABEL_TRANSLATE_ERROR


### PR DESCRIPTION
Add a menuitem under the result for copying the translation to the clipboard.

Fixes issue #61.

There might be a bug, which manifests itself when the result's label is LABEL_LOADING the first time. The copy menuitem is not disabled, I don't know why.